### PR TITLE
Don't call satisfies? in eq

### DIFF
--- a/src/cascade/core.cljc
+++ b/src/cascade/core.cljc
@@ -358,7 +358,6 @@
   ([x y] (trampoline eq clojure.core/identity x y))
   ([k x y]
    (cond
-     (nil? x) #(k (nil? y))
      (identical? x y) #(k true)
      (map? x) #(if (map? y)
                  (if (= (count x) (count y))

--- a/src/cascade/core.cljc
+++ b/src/cascade/core.cljc
@@ -314,6 +314,7 @@
     #(k (= x y))))
 
 
+;; JS native types like number, string, etc. do not match `object`
 #?(:cljs
    (extend-type default
      IEqualWithContinuation

--- a/src/cascade/core.cljc
+++ b/src/cascade/core.cljc
@@ -304,6 +304,23 @@
 (declare eq)
 
 
+(extend-protocol IEqualWithContinuation
+  nil
+  (-eq [_ k y]
+    #(k (nil? y)))
+
+  #?(:clj Object :cljs object)
+  (-eq [x k y]
+    #(k (= x y))))
+
+
+#?(:cljs
+   (extend-type default
+     IEqualWithContinuation
+     (-eq [x k y]
+       #(k (= x y)))))
+
+
 (defn -eq-sequential
   [k xs ys]
   (if-let [x (first xs)]
@@ -334,47 +351,32 @@
     (k true)))
 
 
-(extend-protocol IEqualWithContinuation
-
-  nil (-eq [x k y] #(k (nil? y)))
-
-  #?(:clj clojure.lang.IPersistentMap :cljs IPersistentMap)
-  (-eq [x k y]
-    #(if (map? y)
-       (if (= (count x) (count y))
-         (-eq-unordered k x y)
-         (k false))
-       (k false)))
-
-  #?(:clj clojure.lang.IPersistentSet :cljs IPersistentSet)
-  (-eq [x k y]
-    #(if (set? y)
-       (if (= (count x) (count y))
-         (-eq-unordered k x y)
-         (k false))
-       (k false)))
-
-  #?(:clj clojure.lang.Sequential :cljs ISequential)
-  (-eq [x k y]
-    #(if (sequential? y)
-       (if (and (counted? x) (counted? y)
-                (== (count x) (count y)))
-         (-eq-sequential k x y)
-         (k false))
-       (k false)))
-
-  #?(:clj Object :cljs object) (-eq [x k y] #(k (= x y))))
-
-
 (defn eq
   "Just like clojure.core/=, but works for very nested data structures. Supports
   deep equality of all Clojure data types. For custom data types that you want
   to descend into, implement IEqualWithContinuation."
   ([x y] (trampoline eq clojure.core/identity x y))
   ([k x y]
-   (if (identical? x y)
-     #(k true)
-     (-eq x k y))))
+   (cond
+     (nil? x) #(k (nil? y))
+     (identical? x y) #(k true)
+     (map? x) #(if (map? y)
+                 (if (= (count x) (count y))
+                   (-eq-unordered k x y)
+                   (k false))
+                 (k false))
+     (set? x) #(if (set? y)
+                 (if (= (count x) (count y))
+                   (-eq-unordered k x y)
+                   (k false))
+                 (k false))
+     (sequential? x) #(if (sequential? y)
+                        (if (and (counted? x) (counted? y)
+                                 (== (count x) (count y)))
+                          (-eq-sequential k x y)
+                          (k false))
+                        (k false))
+     :else (-eq x k y))))
 
 
 (comment

--- a/src/cascade/core.cljc
+++ b/src/cascade/core.cljc
@@ -332,9 +332,9 @@
           (k false))
        x y)
       ;; we have x but no y
-      (k false))
+      #(k false))
     ;; we have no x, ensure we have no y
-    (k (empty? ys))))
+    #(k (empty? ys))))
 
 
 (defn -eq-unordered
@@ -349,7 +349,7 @@
      (fn predk [k y]
        (eq k x y))
      ys)
-    (k true)))
+    #(k true)))
 
 
 (defn eq

--- a/test/cascade/core_test.cljc
+++ b/test/cascade/core_test.cljc
@@ -1,7 +1,7 @@
 (ns cascade.core-test
   (:require
    [cascade.core :as c]
-   [clojure.test :refer [deftest is testing]]))
+   [clojure.test :refer [deftest is]]))
 
 
 (deftest t-identity


### PR DESCRIPTION
Per #1, checking `satisfies?` is very slow. This PR removes that call and instead adds a default implementation for `IEqualWithContinuation`.